### PR TITLE
Use byte addressing, add more pointers, add more registers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ jobs:
       - run:
           name: Install debian-packaged dependencies
           command: |
-            apt install -y curl apt-transport-https python build-essential
+	    apt update
+            apt install -y curl apt-transport-https
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
             apt update && apt install -y yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: Install debian-packaged dependencies
           command: |
-	    apt update
+            apt update
             apt install -y curl apt-transport-https
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,16 +6,16 @@ jobs:
     steps:
       - checkout
       - run:
-	  name: Install debian-packaged dependencies
-	  command: |
-	    apt update
-	    apt install -y curl apt-transport-https
-	    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-	    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-	    apt update && apt install -y yarn
+          name: Install debian-packaged dependencies
+          command: |
+            apt update
+            apt install -y curl apt-transport-https
+            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+            echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+            apt update && apt install -y yarn
       - run:
-	  name: Install Node dependencies, run tests
-	  command: |
-	    yarn
-	    yarn build-cli
-	    yarn test
+          name: Install Node dependencies, run tests
+          command: |
+            yarn
+            yarn build-cli
+            yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,4 +17,5 @@ jobs:
           name: Install Node dependencies, run tests
           command: |
             yarn
+	    yarn build-cli
             yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: node:12-slim
+    steps:
+      - checkout
+      - run:
+          name: Install debian-packaged dependencies
+          command: |
+            apt install -y curl apt-transport-https python build-essential
+            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+            echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+            apt update && apt install -y yarn
+      - run:
+          name: Install Node dependencies, run tests
+          command: |
+            yarn
+            yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,16 +6,16 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install debian-packaged dependencies
-          command: |
-            apt update
-            apt install -y curl apt-transport-https
-            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-            echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-            apt update && apt install -y yarn
+	  name: Install debian-packaged dependencies
+	  command: |
+	    apt update
+	    apt install -y curl apt-transport-https
+	    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+	    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+	    apt update && apt install -y yarn
       - run:
-          name: Install Node dependencies, run tests
-          command: |
-            yarn
+	  name: Install Node dependencies, run tests
+	  command: |
+	    yarn
 	    yarn build-cli
-            yarn test
+	    yarn test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#x86e
+# x86e
 
 A simple x86 emulator, debugger, and editor in JavaScript.
 
@@ -18,12 +18,11 @@ $ open localhost:1234
 $ yarn
 $ yarn build-cli
 $ cat examples/plus.c
-int plus(int a, int b) {
-  return a + b;
-}
+int plus(int a, int b) { return a + b; }
 
 int main() { return plus(1, plus(2, 3)); }
-$ gcc - S - masm = intel - o examples / plus.s examples /
-                               plus.c $ node dist examples / plus.s $ echo $
-    ? 6
+$ gcc -S -masm=intel -o examples/plus.s examples/plus.c
+$ node dist examples/plus.s
+$ echo $?
+6
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# x86e
+#x86e
 
 A simple x86 emulator, debugger, and editor in JavaScript.
 
@@ -18,11 +18,12 @@ $ open localhost:1234
 $ yarn
 $ yarn build-cli
 $ cat examples/plus.c
-int plus(int a, int b) { return a + b; }
+int plus(int a, int b) {
+  return a + b;
+}
 
 int main() { return plus(1, plus(2, 3)); }
-$ gcc -S -masm=intel -o examples/plus.s examples/plus.c
-$ node dist examples/plus.s
-$ echo $?
-6
+$ gcc - S - masm = intel - o examples / plus.s examples /
+                               plus.c $ node dist examples / plus.s $ echo $
+    ? 6
 ```

--- a/emulator/index.js
+++ b/emulator/index.js
@@ -8,6 +8,7 @@ async function main() {
     debugInstructions: "Show each instruction with arguments when reached"
   };
   const flags = {};
+  let last = 1;
   process.argv.forEach(function(arg, i) {
     if (!arg.startsWith("--")) return;
 
@@ -25,10 +26,11 @@ async function main() {
 
     if (allFlags[flag]) {
       flags[flag] = process.argv[i + 1];
+      last = i + 1;
     }
   });
 
-  let code = fs.readFileSync(process.argv[2]).toString();
+  let code = fs.readFileSync(process.argv[last + 1]).toString();
 
   if (!flags.kernel) {
     flags.kernel = "LINUX_AMD64";

--- a/emulator/index.js
+++ b/emulator/index.js
@@ -1,23 +1,25 @@
-import * as fs from 'fs';
+import * as fs from "fs";
 
-import { run, startStub } from './x86e';
+import { run, startStub } from "./x86e";
 
 async function main() {
   const allFlags = {
-    kernel: 'Emulate syscalls from one of: linux, darwin',
-    debugInstructions: 'Show each instruction with arguments when reached',
+    kernel: "Emulate syscalls from one of: linux, darwin",
+    debugInstructions: "Show each instruction with arguments when reached"
   };
   const flags = {};
-  process.argv.forEach(function (arg, i) {
-    if (!arg.startsWith('--')) return;
+  process.argv.forEach(function(arg, i) {
+    if (!arg.startsWith("--")) return;
 
     const flag = arg.slice(2);
-    if (flag === 'help') {
-      console.log('x86e.js');
-      console.log('\nFlags:');
-      Object.keys(allFlags).forEach(flag => console.log('\t--' + flag + ': ' + allFlags[flag]));
-      console.log('\nExample:');
-      console.log('\tnode emulate/x86e.js test.asm --kernel darwin');
+    if (flag === "help") {
+      console.log("x86e.js");
+      console.log("\nFlags:");
+      Object.keys(allFlags).forEach(flag =>
+        console.log("\t--" + flag + ": " + allFlags[flag])
+      );
+      console.log("\nExample:");
+      console.log("\tnode emulate/x86e.js test.asm --kernel darwin");
       process.exit(0);
     }
 
@@ -29,19 +31,20 @@ async function main() {
   let code = fs.readFileSync(process.argv[2]).toString();
 
   if (!flags.kernel) {
-    flags.kernel = 'LINUX_AMD64';
+    flags.kernel = "LINUX_AMD64";
   } else {
-    if (!['linux_amd64', 'darwin_amd64'].includes(flags.kernel.toLowerCase())) {
-      console.log('Invalid kernel: ' + flags.kernel);
+    if (!["linux_amd64", "darwin_amd64"].includes(flags.kernel.toLowerCase())) {
+      console.log("Invalid kernel: " + flags.kernel);
       process.exit(1);
     }
 
     flags.kernel = flags.kernel.toUpperCase();
   }
 
-  if (!code.split('\n').filter(l => l.trim().startsWith('_start:')).length) {
-    const _main = !!code.split('\n').filter(l => l.trim().startsWith('_main:')).length;
-    code += '\n' + startStub(flags.kernel, _main ? '_main' : 'main');
+  if (!code.split("\n").filter(l => l.trim().startsWith("_start:")).length) {
+    const _main = !!code.split("\n").filter(l => l.trim().startsWith("_main:"))
+      .length;
+    code += "\n" + startStub(flags.kernel, _main ? "_main" : "main");
   }
 
   // Prevent running until handlers are registered
@@ -50,11 +53,11 @@ async function main() {
     while (ticks.length) {
       await new Promise(done => setTimeout(done, 500));
     }
-  }
+  };
   const { process: p, done } = run(code, clock, flags.kernel, {
     debug: {
-      instructions: flags.debugInstructions,
-    },
+      instructions: flags.debugInstructions
+    }
   });
 
   // Register handlers

--- a/emulator/x86e.js
+++ b/emulator/x86e.js
@@ -1,15 +1,71 @@
-const REGISTERS = [
-  'rdi', 'rsi', 'rsp', 'rbp', 'rax', 'rbx', 'rcx', 'rdx', 'rip', 'r8',
-  'r9', 'r10', 'r11', 'r12', 'r13', 'r14', 'r15', 'cs', 'ds', 'fs',
-  'ss', 'es', 'gs', 'cf', 'zf', 'pf', 'af', 'sf', 'tf', 'if', 'df', 'of',
+const BIT64_REGISTERS = [
+  "rdi",
+  "rsi",
+  "rsp",
+  "rbp",
+  "rax",
+  "rbx",
+  "rcx",
+  "rdx",
+  "rip",
+  "r8",
+  "r9",
+  "r10",
+  "r11",
+  "r12",
+  "r13",
+  "r14",
+  "r15",
+  "cs",
+  "ds",
+  "fs",
+  "ss",
+  "es",
+  "gs",
+  "cf",
+  "zf",
+  "pf",
+  "af",
+  "sf",
+  "tf",
+  "if",
+  "df",
+  "of",
+  "rflags"
 ];
 const BIT32_REGISTERS = [
-  'edi', 'esi', 'esp', 'ebp', 'eax', 'ebx', 'ecx', 'edx', 'eip',
+  "edi",
+  "esi",
+  "esp",
+  "ebp",
+  "eax",
+  "ebx",
+  "ecx",
+  "edx",
+  "eip",
+  "eflags"
+];
+
+const BIT16_REGISTERS = [
+  "ax",
+  "bx",
+  "cx",
+  "dx",
+  "si",
+  "di",
+  "sp",
+  "bp",
+  "cs",
+  "ds",
+  "ss",
+  "es",
+  "ip",
+  "flags"
 ];
 
 const ABIS = {
-  LINUX_AMD64: 'sysv_amd64',
-  DARWIN_AMD64: 'sysv_amd64',
+  LINUX_AMD64: "sysv_amd64",
+  DARWIN_AMD64: "sysv_amd64"
 };
 
 const SYSV_AMD64_SYSCALLS_COMMON = {
@@ -17,9 +73,13 @@ const SYSV_AMD64_SYSCALLS_COMMON = {
     const msg = BigInt(process.registers.rsi);
     const bytes = process.registers.rdx;
     for (let i = 0; i < bytes; i++) {
-      const offsetInMemory = BigInt(Math.floor(i / (process.memoryWidthBytes * 8)));
+      const offsetInMemory = BigInt(
+        Math.floor(i / (process.memoryWidthBytes * 8))
+      );
       const offsetInValue = BigInt(i % process.memoryWidthBytes) * 8n;
-      const byte = process.memory[msg + offsetInMemory] >> offsetInValue & 0xFFn;
+      const byte =
+        (readMemoryBytes(process, msg + offsetInMemory, 1) >> offsetInValue) &
+        0xffn;
       const char = String.fromCharCode(Number(byte));
       process.fd[process.registers.rdi].write(char);
     }
@@ -27,55 +87,61 @@ const SYSV_AMD64_SYSCALLS_COMMON = {
   sys_exit(process) {
     process.done = true;
     process.exit(process.registers.rdi);
-  },
+  }
 };
 
 const SYSCALLS_BY_NAME = {
   LINUX_AMD64: {
     sys_write: {
       id: 1,
-      handler: SYSV_AMD64_SYSCALLS_COMMON.sys_write,
+      handler: SYSV_AMD64_SYSCALLS_COMMON.sys_write
     },
     sys_exit: {
       id: 60,
-      handler: SYSV_AMD64_SYSCALLS_COMMON.sys_exit,
-    },
+      handler: SYSV_AMD64_SYSCALLS_COMMON.sys_exit
+    }
   },
   DARWIN_AMD64: {
     sys_exit: {
       id: 1,
-      handler: SYSV_AMD64_SYSCALLS_COMMON.sys_exit,
+      handler: SYSV_AMD64_SYSCALLS_COMMON.sys_exit
     },
     sys_write: {
       id: 4,
-      handler: SYSV_AMD64_SYSCALLS_COMMON.sys_write,
-    },
-  },
+      handler: SYSV_AMD64_SYSCALLS_COMMON.sys_write
+    }
+  }
 };
 
 const SYSCALLS_BY_ID = Object.keys(SYSCALLS_BY_NAME).reduce(
   (kernels, kernel) => ({
     ...kernels,
-    [kernel]: Object.keys(SYSCALLS_BY_NAME[kernel]).reduce((syscalls, syscall) => ({
-      ...syscalls,
-      [SYSCALLS_BY_NAME[kernel][syscall].id]: SYSCALLS_BY_NAME[kernel][syscall].handler,
-    }), {}),
-  }), {});
+    [kernel]: Object.keys(SYSCALLS_BY_NAME[kernel]).reduce(
+      (syscalls, syscall) => ({
+        ...syscalls,
+        [SYSCALLS_BY_NAME[kernel][syscall].id]:
+          SYSCALLS_BY_NAME[kernel][syscall].handler
+      }),
+      {}
+    )
+  }),
+  {}
+);
 
-export function startStub(kernel, mainLabel = '_main') {
+export function startStub(kernel, mainLabel = "_main") {
   return `_start:
 	CALL ${mainLabel}
 
 	MOV RDI, RAX
 	MOV RAX, ${SYSCALLS_BY_NAME[kernel].sys_exit.id}
-	SYSCALL`
+	SYSCALL`;
 }
 
 function parseLabel(line) {
-  let tokens = '';
+  let tokens = "";
   for (let i = 0; i < line.length; i++) {
     const c = line[i];
-    if (c === ':') {
+    if (c === ":") {
       return tokens;
     }
 
@@ -91,11 +157,16 @@ function debug(line) {
 
 export function isInstruction(line) {
   const t = line.trim();
-  return !(t.startsWith('#') || t.includes(':') || t.startsWith('.') || !t.length);
+  return !(
+    t.startsWith("#") ||
+    t.includes(":") ||
+    t.startsWith(".") ||
+    !t.length
+  );
 }
 
 export function parseInstruction(line) {
-  let currentToken = '';
+  let currentToken = "";
   let instruction;
   const args = [];
 
@@ -103,16 +174,16 @@ export function parseInstruction(line) {
     const c = line[i];
 
     if (!instruction) {
-      if (c === ' ' || c === '\t') {
-	instruction = currentToken.toLowerCase();
-	currentToken = '';
-	continue;
+      if (c === " " || c === "\t") {
+        instruction = currentToken.toLowerCase();
+        currentToken = "";
+        continue;
       }
     } else {
-      if (c === ',') {
-	args.push(currentToken);
-	currentToken = '';
-	continue;
+      if (c === ",") {
+        args.push(currentToken);
+        currentToken = "";
+        continue;
       }
     }
 
@@ -131,51 +202,80 @@ export function parseInstruction(line) {
 }
 
 function parse(code) {
-  const lines = code.split('\n').map(l => l.trim()).filter(Boolean);
+  const lines = code
+    .split("\n")
+    .map(l => l.trim())
+    .filter(Boolean);
   const labels = {};
   const directives = {};
   let linesSkipped = 0;
-  const instructions = lines.map(function (line, i) {
-    if (line.startsWith('.')) {
-      const [, ...directiveAndArgs] = line.split('.');
-      const [directive, ...allArgs] = directiveAndArgs.join('.').split(' ');
-      const args = allArgs.join(' ').split(',').map(a => a.trim());
-      directives[directive] = args.filter(Boolean);
-      linesSkipped++;
-      return;
-    }
+  const instructions = lines
+    .map(function(line, i) {
+      if (line.startsWith(".")) {
+        const [, ...directiveAndArgs] = line.split(".");
+        const [directive, ...allArgs] = directiveAndArgs.join(".").split(" ");
+        const args = allArgs
+          .join(" ")
+          .split(",")
+          .map(a => a.trim());
+        directives[directive] = args.filter(Boolean);
+        linesSkipped++;
+        return;
+      }
 
-    if (line.startsWith('##')) {
-      linesSkipped++;
-      return;
-    }
+      if (line.startsWith("##")) {
+        linesSkipped++;
+        return;
+      }
 
-    const label = parseLabel(line);
-    if (label) {
-      labels[label] = BigInt(i - linesSkipped);
-      linesSkipped++;
-      return;
-    }
+      const label = parseLabel(line);
+      if (label) {
+        labels[label] = BigInt(i - linesSkipped);
+        linesSkipped++;
+        return;
+      }
 
-    return parseInstruction(line);
-  }).filter(Boolean);
+      return parseInstruction(line);
+    })
+    .filter(Boolean);
 
   return { directives, labels, instructions };
 }
 
 function guardArgs(instruction, args, length) {
   if (args.length !== length) {
-    throw new Error(instruction.toUpperCase() + ' expects ' + length + ' args');
+    throw new Error(instruction.toUpperCase() + " expects " + length + " args");
   }
 }
 
-function memoryPush(process, value) {
-  process.memory[--process.registers.rsp] = value;
+function maskBytes(value, bytes) {
+  return value & BigInt(Math.pow(bytes, 8) - 1);
 }
 
-function memoryPop(process, register) {
-  const regValue = process.memory[process.registers.rsp++];
-  process.registers[register] = regValue;
+function writeMemoryBytes(process, address, value, bytes) {
+  for (let i = 0n; i < bytes; i++) {
+    value >>= i * 8n;
+    process.memory[address + i] = value & 0xffn;
+  }
+}
+
+function readMemoryBytes(process, address, bytes) {
+  let value = 0n;
+  for (let i = 0n; i < bytes; i++) {
+    value |= (process.memory[address + i] || 0n) << (i * 8n);
+  }
+  return value;
+}
+
+// Pushing is always 8 bytes
+function memoryPush(process, value) {
+  writeMemoryBytes(process, --process.registers.rsp, value, 8);
+}
+
+// Popping will remove 8 bytes but mask with the register size
+function memoryPop(process, lhs) {
+  const regValue = readMemoryBytes(process, process.registers.rsp++, 8);
+  process.registers[lhs.register] = maskBytes(regValue, lhs.bytes);
 }
 
 function setFlags(process, value) {
@@ -186,41 +286,52 @@ function setFlags(process, value) {
 }
 
 function interpretValue(process, valueRaw, isLValue) {
-  const v = (function () {
+  const v = (function() {
     const value = valueRaw.toLowerCase();
-    if (REGISTERS.includes(value)) {
+    if (BIT64_REGISTERS.includes(value)) {
       if (isLValue) {
-	return value;
-      } else{
-	return process.registers[value];
+        return { register: value, bytes: 8 };
+      } else {
+        return process.registers[value];
       }
     }
 
     if (BIT32_REGISTERS.includes(value)) {
       if (isLValue) {
-	return value.replace('e', 'r');
-      } else{
-	return process.registers[value.replace('e', 'r')];
+        return { register: value.replace("e", "r"), bytes: 4 };
+      } else {
+        return process.registers[value.replace("e", "r")] & 0xffffn;
       }
     }
 
-    if (value.startsWith('dword ptr [')) {
-      const offsetString = value.substring('dword ptr ['.length, value.length - 1).trim();
-      if (offsetString.includes('-')) {
-	const [l, r] = offsetString.split('-').map(l => interpretValue(process, l.trim()));
-	// dword is 4 bytes
-	const address = l - (r / 4n);
-	if (isLValue) {
-	  return address;
-	} else {
-	  return process.memory[address];
-	}
-      }
+    const pointers = [
+      { prefix: "byte", bytes: 1 },
+      { prefix: "word", bytes: 2 },
+      { prefix: "dword", bytes: 4 },
+      { prefix: "qword", bytes: 8 }
+    ];
+    for (const pointer of pointers) {
+      if (value.startsWith(pointer.prefix + " ptr [")) {
+        const offsetString = value
+          .substring(pointer.prefix + " ptr [".length, value.length - 1)
+          .trim();
+        if (offsetString.includes("-")) {
+          const [l, r] = offsetString
+            .split("-")
+            .map(l => interpretValue(process, l.trim()));
+          const address = l - r;
+          if (isLValue) {
+            return { address, bytes: pointer.bytes };
+          } else {
+            return readMemoryBytes(process.memory, address, pointer.bytes);
+          }
+        }
 
-      throw new Error('Unsupported offset calculation: ' + value);
+        throw new Error("Unsupported offset calculation: " + value);
+      }
     }
 
-    return BigInt.asIntN(64, BigInt(value.split(';')[0].trim()));
+    return BigInt.asIntN(64, BigInt(value.split(";")[0].trim()));
   })();
 
   return v;
@@ -237,185 +348,195 @@ async function interpret(process, clock) {
 
     const { instruction, args } = process.instructions[process.registers.rip];
     if (process.flags.debug.instructions) {
-      debug('Instruction: ' + instruction + ' ' + args.join(', '));
+      debug("Instruction: " + instruction + " " + args.join(", "));
     }
 
     switch (instruction) {
-      case 'push': {
-	guardArgs(instruction, args, 1);
-	const regValue = interpretValue(process, args[0]);
-	memoryPush(process, regValue);
-	process.registers.rip++;
-	break;
+      case "push": {
+        guardArgs(instruction, args, 1);
+        const regValue = interpretValue(process, args[0]);
+        memoryPush(process, regValue);
+        process.registers.rip++;
+        break;
       }
-      case 'pop': {
-	guardArgs(instruction, args, 1);
-	const lhs = interpretValue(process, args[0], true);
-	memoryPop(process, lhs);
-	process.registers.rip++;
-	break;
+      case "pop": {
+        guardArgs(instruction, args, 1);
+        const lhs = interpretValue(process, args[0], true);
+        memoryPop(process, lhs);
+        process.registers.rip++;
+        break;
       }
-      case 'mov': {
-	guardArgs(instruction, args, 2);
-	const lhs = interpretValue(process, args[0], true);
-	const rhs = interpretValue(process, args[1]);
-	if (REGISTERS.includes(lhs)) {
-	  process.registers[lhs] = rhs;
-	} else if (BIT32_REGISTERS.includes(lhs)) {
-	  process.registers[lhs.replace('e', 'r')] = rhs;
-	} else {
-	  process.memory[lhs] = rhs;
-	}
-	process.registers.rip++;
-	break;
+      case "mov": {
+        guardArgs(instruction, args, 2);
+        const lhs = interpretValue(process, args[0], true);
+        const rhs = interpretValue(process, args[1]);
+        if (lhs.register) {
+          process.registers[lhs.register] = maskBytes(rhs, lhs.bytes);
+        } else {
+          writeMemoryBytes(process.memory, lhs.address, rhs, lhs.bytes);
+        }
+        process.registers.rip++;
+        break;
       }
-      case 'add': {
-	guardArgs(instruction, args, 2);
-	const lhs = interpretValue(process, args[0], true);
-	const rhs = interpretValue(process, args[1]);
-	const v = process.registers[lhs] += rhs;
-	setFlags(process, v);
-	process.registers.rip++;
-	break;
+      case "add": {
+        guardArgs(instruction, args, 2);
+        const lhs = interpretValue(process, args[0], true);
+        const rhs = interpretValue(process, args[1]);
+        process.registers[lhs.register] = maskBytes(
+          process.registers[lhs.register] + rhs,
+          lhs.bytes
+        );
+        const v = process.registers[lhs.register];
+        setFlags(process, v);
+        process.registers.rip++;
+        break;
       }
-      case 'sub': {
-	guardArgs(instruction, args, 2);
-	const lhs = interpretValue(process, args[0], true);
-	const rhs = interpretValue(process, args[1]);
-	const v = process.registers[lhs] -= rhs;
-	setFlags(process, v);
-	process.registers.rip++;
-	break;
+      case "sub": {
+        guardArgs(instruction, args, 2);
+        const lhs = interpretValue(process, args[0], true);
+        const rhs = interpretValue(process, args[1]);
+        const v = (process.registers[lhs] -= rhs);
+        setFlags(process, v);
+        process.registers.rip++;
+        break;
       }
-      case 'call': {
-	guardArgs(instruction, args, 1);
-	const label = args[0];
-	memoryPush(process, process.registers.rip + 1n);
-	process.registers.rip = process.labels[label];
-	break;
+      case "call": {
+        guardArgs(instruction, args, 1);
+        const label = args[0];
+        memoryPush(process, process.registers.rip + 1n);
+        process.registers.rip = process.labels[label];
+        break;
       }
-      case 'ret': {
-	guardArgs(instruction, args, 0);
-	memoryPop(process, 'rip');
-	break;
+      case "ret": {
+        guardArgs(instruction, args, 0);
+        memoryPop(process, { register: "rip", bytes: 8 });
+        break;
       }
-      case 'nop':
-	guardArgs(instruction, args, 0);
-	process.registers.rip++;
-	break;
-      case 'syscall': {
-	guardArgs(instruction, args, 0);
-	interpretSyscall(process);
-	process.registers.rip++;
-	break;
+      case "nop": {
+        guardArgs(instruction, args, 0);
+        process.registers.rip++;
+        break;
       }
-      case 'cmp': {
-	guardArgs(instruction, args, 2);
-	const lhs = interpretValue(process, args[0]);
-	const rhs = interpretValue(process, args[1]);
-	setFlags(process, lhs - rhs);
-	process.registers.rip++;
-	break;
+      case "syscall": {
+        guardArgs(instruction, args, 0);
+        interpretSyscall(process);
+        process.registers.rip++;
+        break;
       }
-      case 'jmp': {
-	guardArgs(instruction, args, 1);
-	const label = process.labels[args[0]];
-	if (label === undefined) {
-	  throw new Error('Cannot jump to invalid label: ' + args[0]);
-	}
-	process.registers.rip = label;
-	break;
+      case "cmp": {
+        guardArgs(instruction, args, 2);
+        const lhs = interpretValue(process, args[0]);
+        const rhs = interpretValue(process, args[1]);
+        setFlags(process, lhs - rhs);
+        process.registers.rip++;
+        break;
       }
-      case 'jz':
-      case 'je': {
-	guardArgs(instruction, args, 1);
-	const label = process.labels[args[0]];
-	if (label === undefined) {
-	  throw new Error('Cannot jump to invalid label: ' + args[0]);
-	}
+      case "jmp": {
+        guardArgs(instruction, args, 1);
+        const label = process.labels[args[0]];
+        if (label === undefined) {
+          throw new Error("Cannot jump to invalid label: " + args[0]);
+        }
+        process.registers.rip = label;
+        break;
+      }
+      case "jz":
+      case "je": {
+        guardArgs(instruction, args, 1);
+        const label = process.labels[args[0]];
+        if (label === undefined) {
+          throw new Error("Cannot jump to invalid label: " + args[0]);
+        }
 
-	if (process.registers.zf) {
-	  process.registers.rip = label;
-	} else {
-	  process.registers.rip++;
-	}
-	break;
+        if (process.registers.zf) {
+          process.registers.rip = label;
+        } else {
+          process.registers.rip++;
+        }
+        break;
       }
-      case 'jnz':
-      case 'jne': {
-	guardArgs(instruction, args, 1);
-	const label = process.labels[args[0]];
-	if (label === undefined) {
-	  throw new Error('Cannot jump to invalid label: ' + args[0]);
-	}
+      case "jnz":
+      case "jne": {
+        guardArgs(instruction, args, 1);
+        const label = process.labels[args[0]];
+        if (label === undefined) {
+          throw new Error("Cannot jump to invalid label: " + args[0]);
+        }
 
-	if (!process.registers.zf) {
-	  process.registers.rip = label;
-	} else {
-	  process.registers.rip++;
-	}
-	break;
+        if (!process.registers.zf) {
+          process.registers.rip = label;
+        } else {
+          process.registers.rip++;
+        }
+        break;
       }
-      case 'jge': {
-	guardArgs(instruction, args, 1);
-	const label = process.labels[args[0]];
-	if (label === undefined) {
-	  throw new Error('Cannot jump to invalid label: ' + args[0]);
-	}
+      case "jge": {
+        guardArgs(instruction, args, 1);
+        const label = process.labels[args[0]];
+        if (label === undefined) {
+          throw new Error("Cannot jump to invalid label: " + args[0]);
+        }
 
-	if (process.registers.sf === process.registers.of) {
-	  process.registers.rip = label;
-	} else {
-	  process.registers.rip++;
-	}
-	break;
+        if (process.registers.sf === process.registers.of) {
+          process.registers.rip = label;
+        } else {
+          process.registers.rip++;
+        }
+        break;
       }
-      case 'shl': {
-	guardArgs(instruction, args, 2);
-	const lhs = interpretValue(process, args[0], true);
-	const rhs = interpretValue(process, args[1]);
-	const v = process.registers[lhs] <<= rhs;
-	setFlags(process, v);
-	process.registers.rip++;
-	break;
+      case "shl": {
+        guardArgs(instruction, args, 2);
+        const lhs = interpretValue(process, args[0], true);
+        const rhs = interpretValue(process, args[1]);
+        const v = (process.registers[lhs] <<= rhs);
+        setFlags(process, v);
+        process.registers.rip++;
+        break;
       }
-      case 'shr': {
-	guardArgs(instruction, args, 2);
-	const lhs = interpretValue(process, args[0], true);
-	const rhs = interpretValue(process, args[1]);
-	const v = process.registers[lhs] >>= rhs;
-	setFlags(process, v);
-	process.registers.rip++;
-	break;
+      case "shr": {
+        guardArgs(instruction, args, 2);
+        const lhs = interpretValue(process, args[0], true);
+        const rhs = interpretValue(process, args[1]);
+        const v = (process.registers[lhs] >>= rhs);
+        setFlags(process, v);
+        process.registers.rip++;
+        break;
       }
-      case 'and': {
-	guardArgs(instruction, args, 2);
-	const lhs = interpretValue(process, args[0], true);
-	const rhs = interpretValue(process, args[1]);
-	const v = process.registers[lhs] &= rhs;
-	setFlags(process, v);
-	process.registers.rip++;
-	break;
+      case "and": {
+        guardArgs(instruction, args, 2);
+        const lhs = interpretValue(process, args[0], true);
+        const rhs = interpretValue(process, args[1]);
+        const v = (process.registers[lhs] &= rhs);
+        setFlags(process, v);
+        process.registers.rip++;
+        break;
       }
-      case 'or': {
-	guardArgs(instruction, args, 2);
-	const lhs = interpretValue(process, args[0], true);
-	const rhs = interpretValue(process, args[1]);
-	const v = process.registers[lhs] |= rhs;
-	setFlags(process, v);
-	process.registers.rip++;
-	break;
+      case "or": {
+        guardArgs(instruction, args, 2);
+        const lhs = interpretValue(process, args[0], true);
+        const rhs = interpretValue(process, args[1]);
+        const v = (process.registers[lhs] |= rhs);
+        setFlags(process, v);
+        process.registers.rip++;
+        break;
       }
       default:
-	throw new Error('Unsupported instruction: ' + instruction);
+        throw new Error("Unsupported instruction: " + instruction);
     }
 
     if (clock.onTick) clock.onTick();
   }
 }
 
-export function run(code, clock, kernel = 'LINUX_AMD64', flags = { debug: {} }) {
-  const memory = new Array(1024);
+export function run(
+  code,
+  clock,
+  kernel = "LINUX_AMD64",
+  flags = {
+    debug: {}
+  }
+) {
+  const memory = new Array(Math.power(2, 32));
   const { directives, instructions, labels } = parse(code);
   const process = {
     done: false,
@@ -424,9 +545,9 @@ export function run(code, clock, kernel = 'LINUX_AMD64', flags = { debug: {} }) 
     instructions,
     labels,
     kernel,
-    registers: REGISTERS.reduce((rs, r) => ({ ...rs, [r]: 0n }), {}),
+    registers: BIT64_REGISTERS.reduce((rs, r) => ({ ...rs, [r]: 0n }), {}),
     memoryWidthBytes: 8,
-    memory,
+    memory
   };
 
   process.registers.rip = labels._start;

--- a/emulator/x86e.js
+++ b/emulator/x86e.js
@@ -303,7 +303,7 @@ function interpretValue(process, valueRaw, isLValue) {
 
     if (BIT16_REGISTERS.includes(value)) {
       if (isLvalue) {
-	return { register: "r" + value, bytes: 2 };
+        return { register: "r" + value, bytes: 2 };
       }
 
       return process.registers["r" + value] & 0xffn;
@@ -327,7 +327,7 @@ function interpretValue(process, valueRaw, isLValue) {
           const address = l - r;
           if (isLValue) {
             return { address, bytes: pointer.bytes };
-	  }
+          }
 
           return readMemoryBytes(process, address, pointer.bytes);
         }

--- a/emulator/x86e.js
+++ b/emulator/x86e.js
@@ -536,7 +536,7 @@ export function run(
     debug: {}
   }
 ) {
-  const memory = new Array(Math.power(2, 32));
+  const memory = new Array(Math.pow(2, 32) - 1);
   const { directives, instructions, labels } = parse(code);
   const process = {
     done: false,

--- a/examples/hello.asm
+++ b/examples/hello.asm
@@ -1,3 +1,5 @@
+	;; EXPECT_STDOUT: hello\n
+
 	.text
 	.globl main
 

--- a/examples/plus.asm
+++ b/examples/plus.asm
@@ -23,6 +23,4 @@ _main:
   POP RSI
   POP RDI
 
-  MOV RDI, RAX
-  MOV RAX, 1
-  SYSCALL
+  RET

--- a/examples/plus.asm
+++ b/examples/plus.asm
@@ -1,3 +1,4 @@
+	;; EXPECT_STATUS: 6
 	.text
 plus:
   ADD RDI, RSI

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build-cli": "tsc --allowJs --outDir dist emulator/index.js",
     "build-app": "parcel app/index.html",
     "build": "yarn build-cli && yarn build-app",
-    "lint:fix": "prettier --write 'emulator/**'"
+    "lint:fix": "prettier --write 'emulator/**'",
+    "test": "node ./scripts/test.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@babel/plugin-syntax-bigint": "^7.4.4",
     "parcel-bundler": "^1.12.3",
+    "prettier": "^1.17.1",
     "react": "^16.0.0",
     "react-dom": "^16.8.6"
   },
@@ -21,6 +22,7 @@
   "scripts": {
     "build-cli": "tsc --allowJs --outDir dist emulator/index.js",
     "build-app": "parcel app/index.html",
-    "build": "yarn build-cli && yarn build-app"
+    "build": "yarn build-cli && yarn build-app",
+    "lint:fix": "prettier --write 'emulator/**'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build-cli": "tsc --allowJs --outDir dist emulator/index.js",
     "build-app": "parcel app/index.html",
     "build": "yarn build-cli && yarn build-app",
-    "lint:fix": "prettier --write 'emulator/**'",
+    "lint:fix": "prettier --write 'emulator/**' 'scripts/**'",
     "test": "node ./scripts/test.js"
   }
 }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,5 @@
+function main() {
+  
+}
+
+main();

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -68,7 +68,7 @@ function main() {
   });
 
   console.log(`\n${ok} of ${testPrograms.length} tests successful.`);
-  if (ok !== testPrograms.length - 1) {
+  if (ok !== testPrograms.length) {
     process.exit(1);
   }
 }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,61 +1,74 @@
-const cp = require('child_process');
-const fs = require('fs');
-const path = require('path');
+const cp = require("child_process");
+const fs = require("fs");
+const path = require("path");
 
 function getTestPrograms(directory) {
   const files = fs.readdirSync(directory);
-  return files.map(function (file) {
-    const fullPath = path.join(directory, file);
-    const stats = fs.lstatSync(fullPath);
-    if (!stats.isFile()) {
-      return;
-    }
-
-    const contents = fs.readFileSync(fullPath).toString();
-    const lines = contents.split('\n');
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i].trim();
-      const expectedStdoutMarker = ';; EXPECT_STDOUT: ';
-      const expectedStatusMarker = ';; EXPECT_STATUS: ';
-      const program = { name: fullPath };
-      if (line.startsWith(expectedStdoutMarker)) {
-	program.stdout = line.substring(expectedStdoutMarker.length);
-      } else if (line.startsWith(expectedStatusMarker)) {
-	const endOfLine = line.substring(expectedStdoutMarker.length);
-	program.status = Number(endOfLine);
-	if (Number.isNaN(program.status)) {
-	  console.log('Expected status number in test, ' + fullPath + ', got "' + endOfLine);
-	  process.exit(1);
-	}
-      } else {
-	// Program must start with one or both of these expected markers
-	// to be considered test programs.
-	return;
+  return files
+    .map(function(file) {
+      const fullPath = path.join(directory, file);
+      const stats = fs.lstatSync(fullPath);
+      if (!stats.isFile()) {
+        return;
       }
 
-      return program;
-    }
-  }).filter(Boolean);
+      const contents = fs.readFileSync(fullPath).toString();
+      const lines = contents.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i].trim();
+        const expectedStdoutMarker = ";; EXPECT_STDOUT: ";
+        const expectedStatusMarker = ";; EXPECT_STATUS: ";
+        const program = { name: fullPath };
+        if (line.startsWith(expectedStdoutMarker)) {
+          program.stdout = line.substring(expectedStdoutMarker.length);
+        } else if (line.startsWith(expectedStatusMarker)) {
+          const endOfLine = line.substring(expectedStdoutMarker.length);
+          program.status = Number(endOfLine);
+          if (Number.isNaN(program.status)) {
+            console.log(
+              "Expected status number in test, " +
+                fullPath +
+                ', got "' +
+                endOfLine
+            );
+            process.exit(1);
+          }
+        } else {
+          // Program must start with one or both of these expected markers
+          // to be considered test programs.
+          return;
+        }
+
+        return program;
+      }
+    })
+    .filter(Boolean);
 }
 
 function main() {
-  const testPrograms = getTestPrograms(path.join(__dirname, '../examples'));
+  const testPrograms = getTestPrograms(path.join(__dirname, "../examples"));
   let ok = 0;
-  testPrograms.forEach(function (program) {
-    console.log('Running ' + program.name);
+  testPrograms.forEach(function(program) {
+    console.log("Running " + program.name);
 
-    const child = cp.spawnSync('node', ['dist', program.name]);
+    const child = cp.spawnSync("node", ["dist", program.name]);
     if (program.status && child.status !== program.status) {
-      console.log('Test failed. Expected status, ' + program.status + ', got status, ' + child.status + '.');
+      console.log(
+        "Test failed. Expected status, " +
+          program.status +
+          ", got status, " +
+          child.status +
+          "."
+      );
       return;
     }
 
     ok++;
-    console.log('Test successful.');
+    console.log("Test successful.");
   });
 
   console.log(`\n${ok} of ${testPrograms.length} tests successful.`);
-  if (ok !== testPrograms.length -1) {
+  if (ok !== testPrograms.length - 1) {
     process.exit(1);
   }
 }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,5 +1,63 @@
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function getTestPrograms(directory) {
+  const files = fs.readdirSync(directory);
+  return files.map(function (file) {
+    const fullPath = path.join(directory, file);
+    const stats = fs.lstatSync(fullPath);
+    if (!stats.isFile()) {
+      return;
+    }
+
+    const contents = fs.readFileSync(fullPath).toString();
+    const lines = contents.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      const expectedStdoutMarker = ';; EXPECT_STDOUT: ';
+      const expectedStatusMarker = ';; EXPECT_STATUS: ';
+      const program = { name: fullPath };
+      if (line.startsWith(expectedStdoutMarker)) {
+	program.stdout = line.substring(expectedStdoutMarker.length);
+      } else if (line.startsWith(expectedStatusMarker)) {
+	const endOfLine = line.substring(expectedStdoutMarker.length);
+	program.status = Number(endOfLine);
+	if (Number.isNaN(program.status)) {
+	  console.log('Expected status number in test, ' + fullPath + ', got "' + endOfLine);
+	  process.exit(1);
+	}
+      } else {
+	// Program must start with one or both of these expected markers
+	// to be considered test programs.
+	return;
+      }
+
+      return program;
+    }
+  }).filter(Boolean);
+}
+
 function main() {
-  
+  const testPrograms = getTestPrograms(path.join(__dirname, '../examples'));
+  let ok = 0;
+  testPrograms.forEach(function (program) {
+    console.log('Running ' + program.name);
+
+    const child = cp.spawnSync('node', ['dist', program.name]);
+    if (program.status && child.status !== program.status) {
+      console.log('Test failed. Expected status, ' + program.status + ', got status, ' + child.status + '.');
+      return;
+    }
+
+    ok++;
+    console.log('Test successful.');
+  });
+
+  console.log(`\n${ok} of ${testPrograms.length} tests successful.`);
+  if (ok !== testPrograms.length -1) {
+    process.exit(1);
+  }
 }
 
 main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4098,6 +4098,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
+  integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
+
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"


### PR DESCRIPTION
The first pass at this project stored the stack as 64-bit integers. In writing the first post on this project though I realized that it would be much simpler (and more accurate? or even just correct?) to do byte addressing instead. The post walks through the project with byte addressing in mind, but this PR brings the actual code in line and fixes some bugs in the first post. In particular, RSP cannot just be incremented/decremented in the PUSH/POP instructions by 1 anymore as described in the blog post. It must be incremented/decremented by 8 since the stack is in terms of bytes and RSP is 8 bytes.

This also adds support for reading/writing some 32-bit registers and some 16-bit registers. This also adds support for reading/writing 32-bit and 16-bit pointers.

Additionally, this adds a basic test runner to check for some program correctness and hooks up to circleci.